### PR TITLE
Abort when email credentials missing

### DIFF
--- a/job_application_tracker.py
+++ b/job_application_tracker.py
@@ -5,6 +5,7 @@ import csv
 import imaplib
 import email
 import logging
+import sys
 from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
 from email.header import decode_header
@@ -17,6 +18,10 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 EMAIL_USER = os.getenv("EMAIL_USER")
 EMAIL_PASS = os.getenv("EMAIL_PASS")
+
+if not EMAIL_USER or not EMAIL_PASS:
+    logger.error("Missing EMAIL_USER or EMAIL_PASS environment variables")
+    sys.exit(1)
 
 # ─── Patterns ──────────────────────────────────────────────────────────────
 THANK_YOU_PATTERNS = [


### PR DESCRIPTION
## Summary
- Ensure EMAIL_USER and EMAIL_PASS environment variables are present before running
- Exit early with an error log if email credentials are missing

## Testing
- `python -m py_compile job_application_tracker.py`
- `python job_application_tracker.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68ba084a4c2883229bf7ad2d20124144