### PR TITLE
Escape Gmail IMAP raw query

### DIFF
--- a/streamlit_job_tracker_app.py
+++ b/streamlit_job_tracker_app.py
@@ -71,7 +71,8 @@ def run_scan():
         with imaplib.IMAP4_SSL("imap.gmail.com") as mail:
             mail.login(engine.EMAIL_USER, engine.EMAIL_PASS)
             mail.select(mailbox)
-            result, data = mail.search(None, 'X-GM-RAW', raw_query)
+            safe_query = raw_query.replace("\"", "\\\"")
+            result, data = mail.search(None, 'X-GM-RAW', safe_query)
             if result != "OK":
                 st.error("IMAP search failed.")
                 return {}


### PR DESCRIPTION
## Summary
- escape double quotes in the Gmail X-GM-RAW query before issuing the IMAP search so Gmail receives a safe literal

## Testing
- python -m compileall streamlit_job_tracker_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d81cc14c8322bf8731d99fdb641e